### PR TITLE
Avoid crashing on non-bindable IP addresses

### DIFF
--- a/custom_components/upnp_availability/__init__.py
+++ b/custom_components/upnp_availability/__init__.py
@@ -3,9 +3,8 @@ import asyncio
 import logging
 
 import voluptuous as vol
-
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
@@ -50,6 +49,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
     )
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].clear()
 
     return unload_ok

--- a/custom_components/upnp_availability/upnpstatustracker.py
+++ b/custom_components/upnp_availability/upnpstatustracker.py
@@ -194,11 +194,16 @@ class UPnPStatusTracker:
             async_callback = self.handle_alive
 
         for source_address in self.source_addresses:
-            await async_search(
-                service_type=ROOT_DEVICE,
-                source_ip=ip_address(source_address),
-                async_callback=async_callback,
-            )
+            try:
+                await async_search(
+                    service_type=ROOT_DEVICE,
+                    source_ip=ip_address(source_address),
+                    async_callback=async_callback,
+                )
+            except OSError as ex:
+                _LOGGER.warning(
+                    "Unable to search using addr %s: %s", source_address, ex
+                )
 
     async def handle_alive(self, headers):
         """Handle alive messages from async_upnp_client.


### PR DESCRIPTION
Trying to perform SSDP search on IPv6 addresses can cause `OSError: [Errno 22] Invalid argument`

Hopefully fixes #7