### PR TITLE
Bump and adapt to async_upnp_client changes

### DIFF
--- a/custom_components/upnp_availability/manifest.json
+++ b/custom_components/upnp_availability/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/rytilahti/homeassistant-upnp-availability/",
   "requirements": [
-    "async_upnp_client>=0.27"
+    "async_upnp_client>=0.32"
   ],
   "ssdp": {},
   "homekit": {},

--- a/custom_components/upnp_availability/upnpstatustracker.py
+++ b/custom_components/upnp_availability/upnpstatustracker.py
@@ -213,7 +213,7 @@ class UPnPStatusTracker:
     async def _search(self, addr, async_callback):
         try:
             await async_search(
-                service_type=ROOT_DEVICE,
+                search_target=ROOT_DEVICE,
                 source=addr,
                 async_callback=async_callback,
             )


### PR DESCRIPTION
Newer homeassistant releases depend on a newer async_upnp_client which changed naming for searcv target (https://github.com/StevenLooman/async_upnp_client/pull/144),
this PR fixes the naming and makes the integration to depend on >=0.32.

Fixes #12