### PR TITLE
Catch upnp error for global IPv6 address

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   hooks:
   - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8

--- a/cli.py
+++ b/cli.py
@@ -4,7 +4,8 @@ from typing import List
 
 import typer
 
-from custom_components.upnp_availability.upnpstatustracker import UPnPStatusTracker
+from custom_components.upnp_availability.upnpstatustracker import \
+    UPnPStatusTracker
 
 
 def main(

--- a/custom_components/upnp_availability/upnpstatustracker.py
+++ b/custom_components/upnp_availability/upnpstatustracker.py
@@ -217,7 +217,7 @@ class UPnPStatusTracker:
                 source=addr,
                 async_callback=async_callback,
             )
-        except OSError as ex:
+        except (OSError,UpnpError) as ex:
             _LOGGER.warning("Unable to search using addr %s: %s", addr, ex)
 
     async def handle_alive(self, headers):

--- a/custom_components/upnp_availability/upnpstatustracker.py
+++ b/custom_components/upnp_availability/upnpstatustracker.py
@@ -217,7 +217,7 @@ class UPnPStatusTracker:
                 source=addr,
                 async_callback=async_callback,
             )
-        except (OSError,UpnpError) as ex:
+        except (OSError, UpnpError) as ex:
             _LOGGER.warning("Unable to search using addr %s: %s", addr, ex)
 
     async def handle_alive(self, headers):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203


### PR DESCRIPTION
Async-Upnp-client now checks that IPv6 addresses have a scope id and throws an error if they don't. This error can occur if the HA instance has global IPv6 addresses (as they don't have a scope) and would cause upnp-availability to crash. This fix catches the error so it fails gracefully and everything else continues operating.