### PR TITLE
Add checks to verify hacs acceptance

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,0 +1,19 @@
+name: Check for HACS acceptance
+
+on:
+  push:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  hacs:
+    name: Run hassfest and hacs action
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "home-assistant/actions/hassfest@master"
+      - name: HACS Action
+        uses: "hacs/action@main"
+        with:
+          category: "integration"
+          ignore: brands

--- a/cli.py
+++ b/cli.py
@@ -4,8 +4,7 @@ from typing import List
 
 import typer
 
-from custom_components.upnp_availability.upnpstatustracker import \
-    UPnPStatusTracker
+from custom_components.upnp_availability.upnpstatustracker import UPnPStatusTracker
 
 
 def main(

--- a/custom_components/upnp_availability/manifest.json
+++ b/custom_components/upnp_availability/manifest.json
@@ -3,6 +3,7 @@
   "name": "UPnP Availability Sensor",
   "config_flow": true,
   "documentation": "https://github.com/rytilahti/homeassistant-upnp-availability/",
+  "issue_tracker": "https://github.com/rytilahti/homeassistant-upnp-availability/issues",
   "requirements": [
     "async_upnp_client>=0.32"
   ],

--- a/custom_components/upnp_availability/manifest.json
+++ b/custom_components/upnp_availability/manifest.json
@@ -6,10 +6,8 @@
   "requirements": [
     "async_upnp_client>=0.32"
   ],
-  "ssdp": {},
-  "homekit": {},
-  "dependencies": [],
-  "version": "0.0.2",
+  "dependencies": ["network"],
+  "version": "0.0.3",
   "iot_class": "local_push",
   "codeowners": [
     "@rytilahti"

--- a/custom_components/upnp_availability/strings.json
+++ b/custom_components/upnp_availability/strings.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "title": "UPnP Availability",
     "step": {
       "confirm": {
         "title": "UPnP Availability",

--- a/custom_components/upnp_availability/translations/en.json
+++ b/custom_components/upnp_availability/translations/en.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "title": "UPnP Availability",
     "step": {
       "confirm": {
         "title": "UPnP Availability",

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,4 @@
 {
   "name": "UPnP Availability",
-  "domains": ["binary_sensor"],
-  "iot_class": "local_push",
   "render_readme": true
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203
+[isort]
+profile = black


### PR DESCRIPTION
Even if this is not submitted to hacs inclusion, the regular checks can be a canary to see when something is going to break.