### PR TITLE
Use device icon as entity_picture

### DIFF
--- a/custom_components/upnp_availability/binary_sensor.py
+++ b/custom_components/upnp_availability/binary_sensor.py
@@ -116,3 +116,8 @@ class UPNPBinarySensor(BinarySensorEntity):
     def extra_state_attributes(self):
         """Provide attributes for display on device card."""
         return self.dev.info
+
+    @property
+    def entity_picture(self) -> str | None:
+        """Return device icon."""
+        return self.dev.icon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-async_upnp_client>=0.21
+async_upnp_client>=0.32
 attrs


### PR DESCRIPTION
Use the device reported icon as `entity_picture`:
![image](https://user-images.githubusercontent.com/3705853/205511662-61b5de17-4c02-4cc7-ac13-69820176b5e5.png)


Related to #17