### PR TITLE
Fix event callbacks to use async variants

### DIFF
--- a/custom_components/upnp_availability/manifest.json
+++ b/custom_components/upnp_availability/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/rytilahti/homeassistant-upnp-availability/",
   "issue_tracker": "https://github.com/rytilahti/homeassistant-upnp-availability/issues",
   "requirements": [
-    "async_upnp_client>=0.32"
+    "async_upnp_client>=0.33"
   ],
   "dependencies": ["network"],
   "version": "0.0.3",

--- a/custom_components/upnp_availability/upnpstatustracker.py
+++ b/custom_components/upnp_availability/upnpstatustracker.py
@@ -306,9 +306,9 @@ class UPnPStatusTracker:
 
         for srcip in self.source_addresses:
             self.listeners[srcip] = listener = SsdpAdvertisementListener(
-                on_alive=self.handle_alive,
-                on_byebye=self.handle_bye,
-                on_update=self.handle_update,
+                async_on_alive=self.handle_alive,
+                async_on_byebye=self.handle_bye,
+                async_on_update=self.handle_update,
             )
             await listener.async_start()
 


### PR DESCRIPTION
This fixes an issue where the callbacks were not awaited anymore due to a breaking change related to how event callbacks are handled by  `async_upnp_client`: https://github.com/StevenLooman/async_upnp_client/pull/153

Fixes #20