### PR TITLE
Mark device as available even when device info fetch fails

### DIFF
--- a/custom_components/upnp_availability/upnpstatustracker.py
+++ b/custom_components/upnp_availability/upnpstatustracker.py
@@ -253,8 +253,7 @@ class UPnPStatusTracker:
                     await self.new_device_cb(dev)
             # TODO: should fetching be re-tried?
             except (UpnpError, TimeoutError, ParseError) as ex:
-                _LOGGER.error("Unable to fetch device info for %s: %s", dev, ex)
-                return
+                _LOGGER.warning("Unable to fetch device info for %s: %s", dev, ex)
 
         dev = self.devices[udn]
         dev.set_alive(True)


### PR DESCRIPTION
This makes the device marked as available even when fetching the device description file fails.
Also downgrades the log message from error to warning.

Related to #24