### PR TITLE
Create a background task for initial discovery

### DIFF
--- a/custom_components/upnp_availability/binary_sensor.py
+++ b/custom_components/upnp_availability/binary_sensor.py
@@ -48,7 +48,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         new_device_cb=add_new_device,
         state_changed_cb=update_device,
     )
-    await tracker.find_devices()
+    hass.async_create_background_task(
+        tracker.find_devices(), "upnp-availability initial discovery"
+    )
     await tracker.listen()
 
     async def stop_tracker(event):


### PR DESCRIPTION
This avoids blocking the event loop during the startup and speeding it up, idea from https://github.com/home-assistant/core/pull/111788 