### PR TITLE
Silence byes from unknown devices

### DIFF
--- a/custom_components/upnp_availability/upnpstatustracker.py
+++ b/custom_components/upnp_availability/upnpstatustracker.py
@@ -288,7 +288,7 @@ class UPnPStatusTracker:
 
         udn = headers["_udn"]
         if udn not in self.devices:
-            _LOGGER.error("Got bye from unknown device: %s", udn)
+            _LOGGER.debug("Got bye from unknown device, ignoring: %s", udn)
             return
 
         dev = self.devices[udn]


### PR DESCRIPTION
There is no reason to be verbose on byes from unknown devices, so drop the log level to DEBUG.
This also mirrors the behavior of unexpected updates to avoid spamming logs.

Fixes #33