### PR TITLE
Add async_upnp_client to loggers

### DIFF
--- a/custom_components/upnp_availability/manifest.json
+++ b/custom_components/upnp_availability/manifest.json
@@ -9,6 +9,7 @@
   "documentation": "https://github.com/rytilahti/homeassistant-upnp-availability/",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rytilahti/homeassistant-upnp-availability/issues",
+  "loggers": ["async_upnp_client"],
   "requirements": [
     "async_upnp_client>=0.33"
   ],


### PR DESCRIPTION
This will make it possible to enable debug logging for the raw ssdp/upnp directly from homeassistant ui.